### PR TITLE
Update automatic-derivation-of-config.md

### DIFF
--- a/docs/automatic-derivation-of-config.md
+++ b/docs/automatic-derivation-of-config.md
@@ -30,7 +30,7 @@ case class MyConfig(x: X)
 // Setting up imports
 
 import zio._
-import zio.config._, 
+import zio.config._
 import zio.config.typesafe._
 import zio.config.magnolia._
 


### PR DESCRIPTION
remove dangling comma typo from example imports in the docs